### PR TITLE
Remove DSA host key generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine
 
 RUN apk update && \
     apk add knock git bash openssh && \
-    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa && \
-    ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
+    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
 
 COPY rootfs /
 RUN mkdir -p /etc/ssh/sshd_principals/


### PR DESCRIPTION
This is ancient, and busted, and evidently no-longer included in Alpine's version of openssh or whatever